### PR TITLE
Implement Path.Builder

### DIFF
--- a/PathTools/CubicBezierCurve.swift
+++ b/PathTools/CubicBezierCurve.swift
@@ -175,10 +175,10 @@ func cardano(curve: CubicBezierCurve, line: Line) -> Set<Double> {
     let a = (3 * pa - 6 * pb + 3 * pc) / d
     
     let p = (3 * b - a * a) / 3
-    let p3 = p/3
+    let p3 = p / 3
     let q = (2 * pow(a,3) - 9 * a * b + 27 * c) / 27
-    let q2 = q/2
-    let discriminant = pow(q2,2) + pow(p3,3)
+    let q2 = q / 2
+    let discriminant = pow(q2, 2) + pow(p3, 3)
     
     if discriminant < 0 {
         let mp3 = -p / 3
@@ -188,9 +188,9 @@ func cardano(curve: CubicBezierCurve, line: Line) -> Set<Double> {
         let cosphi = t < -1 ? -1 : t > 1 ? 1 : t
         let phi = acos(cosphi)
         let t1 = 2 * cubeRoot(r)
-        let x1 = t1 * cos(phi / 3) - a / 3;
-        let x2 = t1 * cos((phi + tau)/3) - a / 3;
-        let x3 = t1 * cos((phi + 2 * tau) / 3) - a / 3;
+        let x1 = t1 * cos(phi / 3) - a / 3
+        let x2 = t1 * cos((phi + tau)/3) - a / 3
+        let x3 = t1 * cos((phi + 2 * tau) / 3) - a / 3
         return [x1, x2, x3]
     } else if discriminant == 0 {
         let u1 = q2 < 0 ? cubeRoot(-q2) : -cubeRoot(q2)

--- a/PathTools/CubicBezierCurve.swift
+++ b/PathTools/CubicBezierCurve.swift
@@ -129,6 +129,9 @@ public struct CubicBezierCurve: BezierCurve {
 }
 
 /// - TODO: Move somewhere meaningful.
+let tau: Double = 2 * .pi
+
+/// - TODO: Move somewhere meaningful.
 func cubeRoot(_ value: Double) -> Double {
     return value > 0 ? pow(value, 1/3) : -pow(-value, 1/3)
 }
@@ -158,9 +161,7 @@ func cardano(curve: CubicBezierCurve, line: Line) -> Set<Double> {
             }
         )
     }
-    
-    let tau: Double = 2 * .pi
-    
+
     let aligned = align(curve: curve, with: line)
     
     let pa = aligned.start.y

--- a/PathTools/CubicBezierCurve.swift
+++ b/PathTools/CubicBezierCurve.swift
@@ -148,15 +148,13 @@ func cardano(curve: CubicBezierCurve, line: Line) -> Set<Double> {
     func align(curve: CubicBezierCurve, with line: Line) -> CubicBezierCurve {
         
         let points = [curve.start, curve.control1, curve.control2, curve.end]
-        let tx = line.start.x
-        let ty = line.start.y
-        let a = -atan2(line.end.y - ty, line.end.x - tx)
+        let a = -atan2(line.end.y - line.start.y, line.end.x - line.start.x)
         
         return CubicBezierCurve(
             points.map { point in
                 Point(
-                    x: (point.x - tx) * cos(a) - (point.y - ty) * sin(a),
-                    y: (point.x - tx) * sin(a) + (point.y - ty) * cos(a)
+                    x: (point.x - line.start.x) * cos(a) - (point.y - line.start.y) * sin(a),
+                    y: (point.x - line.start.x) * sin(a) + (point.y - line.start.y) * cos(a)
                 )
             }
         )

--- a/PathTools/CubicBezierCurve.swift
+++ b/PathTools/CubicBezierCurve.swift
@@ -189,7 +189,7 @@ func cardano(curve: CubicBezierCurve, line: Line) -> Set<Double> {
         let phi = acos(cosphi)
         let t1 = 2 * cubeRoot(r)
         let x1 = t1 * cos(phi / 3) - a / 3
-        let x2 = t1 * cos((phi + tau)/3) - a / 3
+        let x2 = t1 * cos((phi + tau) / 3) - a / 3
         let x3 = t1 * cos((phi + 2 * tau) / 3) - a / 3
         return [x1, x2, x3]
     } else if discriminant == 0 {

--- a/PathTools/Path+CGPath.swift
+++ b/PathTools/Path+CGPath.swift
@@ -39,7 +39,7 @@ extension Path {
 
     
     /// Creates a `Path` with a `CGPath`.
-    public convenience init(_ cgPath: CGPath?) {
+    public init(_ cgPath: CGPath?) {
         var pathElements: [PathElement] = []
         withUnsafeMutablePointer(to: &pathElements) { elementsPointer in
             cgPath?.apply(info: elementsPointer) { (userInfo, nextElementPointer) in

--- a/PathTools/Path+Rectangle.swift
+++ b/PathTools/Path+Rectangle.swift
@@ -14,12 +14,13 @@ extension Path {
     
     /// - Returns: `Path` with a rectangle shape defined by `rectangle`.
     public static func rectangle(_ rect: Rectangle) -> Path {
-        return Path()
+        let builder = Path.Builder()
             .move(to: rect.origin)
             .addLine(to: Point(x: rect.maxX, y: rect.minY))
             .addLine(to: Point(x: rect.maxX, y: rect.maxY))
             .addLine(to: Point(x: rect.minX, y: rect.maxY))
             .close()
+        return builder.build()
     }
 
     /// - Returns: `Path` with a rectangle shape with the given `origin` and `size`.

--- a/PathTools/Path+Rectangle.swift
+++ b/PathTools/Path+Rectangle.swift
@@ -14,7 +14,7 @@ extension Path {
     
     /// - Returns: `Path` with a rectangle shape defined by `rectangle`.
     public static func rectangle(_ rect: Rectangle) -> Path {
-        let builder = Path.Builder()
+        let builder = Path.builder
             .move(to: rect.origin)
             .addLine(to: Point(x: rect.maxX, y: rect.minY))
             .addLine(to: Point(x: rect.maxX, y: rect.maxY))

--- a/PathTools/Path+Square.swift
+++ b/PathTools/Path+Square.swift
@@ -14,7 +14,7 @@ extension Path {
     
     public static func square(center: Point, width: Double) -> Path {
         let origin = Point(x: center.x - 0.5 * width, y: center.y - 0.5 * width)
-        let builder = Path.Builder()
+        let builder = Path.builder
             .move(to: origin)
             .addLine(to: Point(x: origin.x + width, y: origin.y))
             .addLine(to: Point(x: origin.x + width, y: origin.y + width))

--- a/PathTools/Path+Square.swift
+++ b/PathTools/Path+Square.swift
@@ -14,11 +14,12 @@ extension Path {
     
     public static func square(center: Point, width: Double) -> Path {
         let origin = Point(x: center.x - 0.5 * width, y: center.y - 0.5 * width)
-        return Path()
+        let builder = Path.Builder()
             .move(to: origin)
             .addLine(to: Point(x: origin.x + width, y: origin.y))
             .addLine(to: Point(x: origin.x + width, y: origin.y + width))
             .addLine(to: Point(x: origin.x, y: origin.y + width))
             .close()
+        return builder.build()
     }
 }

--- a/PathTools/Path.swift
+++ b/PathTools/Path.swift
@@ -46,7 +46,7 @@ public struct Path {
         
         /// Move to `point`.
         ///
-        /// - returns: `self`
+        /// - returns: `self`.
         @discardableResult
         public func move(to point: Point) -> ExposesAllElements {
             elements.append(.move(point))

--- a/PathTools/Path.swift
+++ b/PathTools/Path.swift
@@ -10,12 +10,27 @@ import Collections
 import ArithmeticTools
 import GeometryTools
 
+public protocol ExposesMoveTo {
+    func move(to point: Point) -> ExposesAllElements
+}
+
+public protocol ExposesBuild {
+    func build() -> Path
+}
+
+public protocol ExposesAllElements: ExposesMoveTo, ExposesBuild {
+    func addLine(to point: Point) -> ExposesAllElements
+    func addQuadCurve(to point: Point, control: Point) -> ExposesAllElements
+    func addCurve(to point: Point, control1: Point, control2: Point) -> ExposesAllElements
+    func close() -> ExposesBuild & ExposesMoveTo
+}
+
 /// - TODO: Conform to `Collection` protocols
 public struct Path {
     
     // MARK: - Nested Types
     
-    public final class Builder {
+    public final class Builder: ExposesAllElements {
         
         private var elements: [PathElement] = []
         
@@ -30,7 +45,7 @@ public struct Path {
         ///
         /// - returns: `self`
         @discardableResult
-        public func move(to point: Point) -> Builder {
+        public func move(to point: Point) -> ExposesAllElements {
             elements.append(.move(point))
             return self
         }
@@ -39,7 +54,7 @@ public struct Path {
         ///
         /// - returns: `self`.
         @discardableResult
-        public func addLine(to point: Point) -> Builder {
+        public func addLine(to point: Point) -> ExposesAllElements {
             elements.append(.line(point))
             return self
         }
@@ -48,7 +63,7 @@ public struct Path {
         ///
         /// - returns: `self`.
         @discardableResult
-        public func addQuadCurve(to point: Point, control: Point) -> Builder {
+        public func addQuadCurve(to point: Point, control: Point) -> ExposesAllElements {
             elements.append(.quadCurve(point, control))
             return self
         }
@@ -57,7 +72,7 @@ public struct Path {
         ///
         /// - returns: `self`.
         @discardableResult
-        public func addCurve(to point: Point, control1: Point, control2: Point) -> Builder {
+        public func addCurve(to point: Point, control1: Point, control2: Point) -> ExposesAllElements {
             elements.append(.curve(point, control1, control2))
             return self
         }
@@ -66,7 +81,7 @@ public struct Path {
         ///
         /// - returns: `self`.
         @discardableResult
-        public func close() -> Builder {
+        public func close() -> ExposesBuild & ExposesMoveTo {
             elements.append(.close)
             return self
         }
@@ -76,6 +91,14 @@ public struct Path {
         public func build() -> Path {
             return Path(elements)
         }
+    }
+    
+    // MARK: - Type Properties
+    
+    /// - Returns: `Builder` object that only exposes the `move(to:)` method, as it is a
+    /// required first element for a `Path`.
+    public static var builder: ExposesMoveTo {
+        return Builder()
     }
     
     // MARK: - Instance Properties

--- a/PathTools/Path.swift
+++ b/PathTools/Path.swift
@@ -10,14 +10,17 @@ import Collections
 import ArithmeticTools
 import GeometryTools
 
+/// Interface exposed upon beginning the `Path` step-building patter.
 public protocol ExposesMoveTo {
     func move(to point: Point) -> ExposesAllElements
 }
 
+/// Interface exposed (along with `ExposesMoveTo`) after adding a `close()` element.
 public protocol ExposesBuild {
     func build() -> Path
 }
 
+/// Interface exposing all possible path element build steps.
 public protocol ExposesAllElements: ExposesMoveTo, ExposesBuild {
     func addLine(to point: Point) -> ExposesAllElements
     func addQuadCurve(to point: Point, control: Point) -> ExposesAllElements
@@ -30,7 +33,7 @@ public struct Path {
     
     // MARK: - Nested Types
     
-    public final class Builder: ExposesAllElements {
+    private final class Builder: ExposesAllElements {
         
         private var elements: [PathElement] = []
         

--- a/PathTools/Path.swift
+++ b/PathTools/Path.swift
@@ -19,6 +19,11 @@ public struct Path {
         
         private var elements: [PathElement] = []
         
+        // MARK: - Initializers
+        
+        /// Creates a `Path.Builder` ready to build a `Path`.
+        public init() { }
+        
         // MARK: - Instance Methods
         
         /// Move to `point`.

--- a/PathTools/Path.swift
+++ b/PathTools/Path.swift
@@ -71,11 +71,11 @@ public class Path {
     @discardableResult
     public func addCurve(
         to point: Point,
-        controlPoint1: Point,
-        controlPoint2: Point
+        control1: Point,
+        control2: Point
     ) -> Path
     {
-        elements.append(.curve(point, controlPoint1, controlPoint2))
+        elements.append(.curve(point, control1, control2))
         return self
     }
     

--- a/PathTools/Path.swift
+++ b/PathTools/Path.swift
@@ -15,7 +15,7 @@ public class Path {
     // MARK: - Instance Properties
     
     public var isShape: Bool {
-        return elements.allSatisfy { $0.isVertex }
+        return elements.all { $0.isVertex }
     }
     
     /// - Returns: `true` if there are no non-`.close` elements contained herein. Otherwise,

--- a/PathTools/Path.swift
+++ b/PathTools/Path.swift
@@ -10,7 +10,68 @@ import Collections
 import ArithmeticTools
 import GeometryTools
 
-public class Path {
+/// - TODO: Conform to `Collection` protocols
+public struct Path {
+    
+    // MARK: - Nested Types
+    
+    public final class Builder {
+        
+        private var elements: [PathElement] = []
+        
+        // MARK: - Instance Methods
+        
+        /// Move to `point`.
+        ///
+        /// - returns: `self`
+        @discardableResult
+        public func move(to point: Point) -> Builder {
+            elements.append(.move(point))
+            return self
+        }
+        
+        /// Add line to `point`.
+        ///
+        /// - returns: `self`.
+        @discardableResult
+        public func addLine(to point: Point) -> Builder {
+            elements.append(.line(point))
+            return self
+        }
+        
+        /// Add curve to `point`, with a single control point.
+        ///
+        /// - returns: `self`.
+        @discardableResult
+        public func addQuadCurve(to point: Point, control: Point) -> Builder {
+            elements.append(.quadCurve(point, control))
+            return self
+        }
+        
+        /// Add curve to `point`, with two control points.
+        ///
+        /// - returns: `self`.
+        @discardableResult
+        public func addCurve(to point: Point, control1: Point, control2: Point) -> Builder {
+            elements.append(.curve(point, control1, control2))
+            return self
+        }
+        
+        /// Close path.
+        ///
+        /// - returns: `self`.
+        @discardableResult
+        public func close() -> Builder {
+            elements.append(.close)
+            return self
+        }
+
+        
+        /// - Returns: `Path` value with the elements constructed thus far.
+        public func build() -> Path {
+            return Path(elements)
+        }
+    }
     
     // MARK: - Instance Properties
     
@@ -24,77 +85,14 @@ public class Path {
         return elements.filter { $0 != .close }.isEmpty
     }
     
-    internal var elements: [PathElement] = []
+    /// `PathElements` comprising `Path`.
+    internal let elements: [PathElement]
         
     // MARK: - Initializers
-    
-    /// Creates an empty `Path`.
-    public init() { }
     
     /// Create a `Path` with an array of `PathElement` values.
     public init(_ elements: [PathElement]) {
         self.elements = elements
-    }
-    
-    // MARK: - Instance Methods
-    
-    /// Move to `point`.
-    ///
-    /// - returns: `self`
-    @discardableResult
-    public func move(to point: Point) -> Path {
-        elements.append(.move(point))
-        return self
-    }
-    
-    /// Add line to `point`.
-    ///
-    /// - returns: `self`.
-    @discardableResult
-    public func addLine(to point: Point) -> Path {
-        elements.append(.line(point))
-        return self
-    }
-    
-    /// Add curve to `point`, with a single control point.
-    ///
-    /// - returns: `self`.
-    @discardableResult
-    public func addQuadCurve(to point: Point, controlPoint: Point) -> Path {
-        elements.append(.quadCurve(point, controlPoint))
-        return self
-    }
-
-    /// Add curve to `point`, with two control points.
-    ///
-    /// - returns: `self`.
-    @discardableResult
-    public func addCurve(
-        to point: Point,
-        control1: Point,
-        control2: Point
-    ) -> Path
-    {
-        elements.append(.curve(point, control1, control2))
-        return self
-    }
-    
-    /// Close path.
-    ///
-    /// - returns: `self`.
-    @discardableResult
-    public func close() -> Path {
-        elements.append(.close)
-        return self
-    }
-    
-    /// Append the elements of another `Path` to this one.
-    ///
-    /// - returns: `self`.
-    @discardableResult
-    public func append(_ path: Path) -> Path {
-        elements.append(contentsOf: path.elements)
-        return self
     }
 }
 
@@ -125,5 +123,12 @@ extension Path: CustomStringConvertible {
     
     public var description: String {
         return elements.map { "\($0)" }.joined(separator: "\n")
+    }
+}
+
+extension Array {
+    
+    public func appending(contentsOf other: Array) -> Array {
+        return self + other
     }
 }

--- a/PathToolsTests/PathElementTests.swift
+++ b/PathToolsTests/PathElementTests.swift
@@ -33,14 +33,14 @@ class PathElementTests: XCTestCase {
             )
             let cgPath = bezierPath.cgPath
             let result = Path(cgPath)
-            let expected = Path()
+            let expected = Path.Builder()
                 .move(to: Point())
                 .addCurve(
                     to: Point(x: 1, y: 1),
-                    controlPoint1: Point(x: 0.5, y: 0),
-                    controlPoint2: Point(x: 1, y: 0.5)
+                    control1: Point(x: 0.5, y: 0),
+                    control2: Point(x: 1, y: 0.5)
                 )
-            
+                .build()
             XCTAssertEqual(result, expected)
             
         #endif
@@ -54,9 +54,10 @@ class PathElementTests: XCTestCase {
             bezierPath.addQuadCurve(to: CGPoint(x: 1, y: 1), controlPoint: CGPoint(x: 1, y: 0))
             let cgPath = bezierPath.cgPath
             let result = Path(cgPath)
-            let expected = Path()
+            let expected = Path.Builder()
                 .move(to: Point())
-                .addQuadCurve(to: Point(x: 1, y: 1), controlPoint: Point(x: 1, y: 0))
+                .addQuadCurve(to: Point(x: 1, y: 1), control: Point(x: 1, y: 0))
+                .build()
             
             XCTAssertEqual(result, expected)
             

--- a/PathToolsTests/PathElementTests.swift
+++ b/PathToolsTests/PathElementTests.swift
@@ -54,7 +54,7 @@ class PathElementTests: XCTestCase {
             bezierPath.addQuadCurve(to: CGPoint(x: 1, y: 1), controlPoint: CGPoint(x: 1, y: 0))
             let cgPath = bezierPath.cgPath
             let result = Path(cgPath)
-            let expected = Path.Builder()
+            let expected = Path.builder
                 .move(to: Point())
                 .addQuadCurve(to: Point(x: 1, y: 1), control: Point(x: 1, y: 0))
                 .build()

--- a/PathToolsTests/PathElementTests.swift
+++ b/PathToolsTests/PathElementTests.swift
@@ -33,7 +33,7 @@ class PathElementTests: XCTestCase {
             )
             let cgPath = bezierPath.cgPath
             let result = Path(cgPath)
-            let expected = Path.Builder()
+            let expected = Path.builder
                 .move(to: Point())
                 .addCurve(
                     to: Point(x: 1, y: 1),

--- a/PathToolsTests/PathTests.swift
+++ b/PathToolsTests/PathTests.swift
@@ -47,8 +47,8 @@ class PathTests: XCTestCase {
             .addQuadCurve(to: Point(x: 300, y: 0), controlPoint: Point(x: 200, y: 100))
             .addCurve(
                 to: Point(x: 200, y: 150),
-                controlPoint1: Point(x: 400, y: 200),
-                controlPoint2: Point(x: 100, y: 200)
+                control1: Point(x: 400, y: 200),
+                control2: Point(x: 100, y: 200)
             )
         
         print(path)

--- a/PathToolsTests/PathTests.swift
+++ b/PathToolsTests/PathTests.swift
@@ -13,12 +13,12 @@ import GeometryTools
 class PathTests: XCTestCase {
 
     func testMoveTo() {
-        let path = Path.Builder().move(to: Point()).build()
+        let path = Path.builder.move(to: Point()).build()
         XCTAssertEqual(path.count, 1)
     }
     
     func testMoveToLineTo() {
-        let path = Path.Builder()
+        let path = Path.builder
             .move(to: Point())
             .addLine(to: Point())
             .build()
@@ -32,7 +32,7 @@ class PathTests: XCTestCase {
     
     func testCustomStringConvertible() {
         
-        let builder = Path.Builder()
+        let builder = Path.builder
             .move(to: Point(x: 100, y: 100))
             .addLine(to: Point(x: 200, y: 200))
             .addQuadCurve(to: Point(x: 300, y: 0), control: Point(x: 200, y: 100))

--- a/PathToolsTests/PathTests.swift
+++ b/PathToolsTests/PathTests.swift
@@ -12,26 +12,17 @@ import GeometryTools
 
 class PathTests: XCTestCase {
 
-    func testInit() {
-        let _ = Path()
-    }
-    
     func testMoveTo() {
-        let path = Path()
-            .move(to: Point())
+        let path = Path.Builder().move(to: Point()).build()
         XCTAssertEqual(path.count, 1)
     }
     
     func testMoveToLineTo() {
-        let path = Path()
+        let path = Path.Builder()
             .move(to: Point())
             .addLine(to: Point())
+            .build()
         XCTAssertEqual(path.count, 2)
-    }
-    
-    func testCGPathInit() {
-        let path = Path()
-        let _ = path.cgPath
     }
     
     func testInitWithCGRect() {
@@ -41,15 +32,16 @@ class PathTests: XCTestCase {
     
     func testCustomStringConvertible() {
         
-        let path = Path()
+        let builder = Path.Builder()
             .move(to: Point(x: 100, y: 100))
             .addLine(to: Point(x: 200, y: 200))
-            .addQuadCurve(to: Point(x: 300, y: 0), controlPoint: Point(x: 200, y: 100))
+            .addQuadCurve(to: Point(x: 300, y: 0), control: Point(x: 200, y: 100))
             .addCurve(
                 to: Point(x: 200, y: 150),
                 control1: Point(x: 400, y: 200),
                 control2: Point(x: 100, y: 200)
             )
+        let path = builder.build()
         
         print(path)
     }


### PR DESCRIPTION
Creates a fluent interface for building a `Path`. Leaves `Path` in value-type land, while decoupling the modes of construction from the data.